### PR TITLE
Adding fake categories for DiMuon: ch2 and ch4

### DIFF
--- a/plotting/DiMuon.py
+++ b/plotting/DiMuon.py
@@ -34,16 +34,18 @@ from create_datacard_v3 import create_datacard_ch1, create_datacard_ch2, create_
 ROOT.ROOT.EnableImplicitMT()
 
 
-def get_DiMuonBkg(selection, var_index):
+def get_DiMuonBkg(selection, var_index, isfail):
     
     tree_name = 'BTo3Mu'
     tree_dir = '/pnfs/psi.ch/cms/trivcat/store/user/friti/dataframes_Dec2021/'
         
     dataframe = {}
-    dataframe["SR"] = ROOT.RDataFrame(tree_name,'%s/data_ptmax_merged_fakerate.root'%(tree_dir))
+    #dataframe["SR"] = ROOT.RDataFrame(tree_name,'%s/data_ptmax_merged_fakerate.root'%(tree_dir))
+    dataframe["SR"] = ROOT.RDataFrame(tree_name,'%s/data_fakerate_only_iso.root'%(tree_dir))
     #dataframe["ResonantTrg"] = ROOT.RDataFrame(tree_name,'%s/data_ptmax_merged_fakerate.root'%(tree_dir)) 
     #dataframe["NonResonantTrg"] = ROOT.RDataFrame(tree_name,'%s/datalowmass_ptmax_merged_fakerate.root'%(tree_dir))
-    dataframe["SBs"] = ROOT.RDataFrame(tree_name,{'%s/datalowmass_ptmax_merged_fakerate_2.root'%(tree_dir), '%s/data_ptmax_merged_fakerate.root'%(tree_dir)})
+    #dataframe["SBs"] = ROOT.RDataFrame(tree_name,{'%s/datalowmass_ptmax_merged_fakerate_2.root'%(tree_dir), '%s/data_ptmax_merged_fakerate.root'%(tree_dir)})
+    dataframe["SBs"] = ROOT.RDataFrame(tree_name,{'%s/datalowmass_fakerate_only_iso.root'%(tree_dir), '%s/data_fakerate_only_iso.root'%(tree_dir)})
     regions = list(dataframe.keys())
     
     print("==================================")
@@ -184,33 +186,48 @@ def get_DiMuonBkg(selection, var_index):
         }
         """)
 
-    if var_index == 0: 
+    if var_index == 0:
         dataframe["SBs"] = dataframe["SBs"].Filter(filterLSB).Define("Q_sq_extrap", "SB_extrap(Bpt_reco, 0, Jpsi_scale, mu1pt, mu1eta, mu1phi, mu1mass, mu2pt, mu2eta, mu2phi, mu2mass, kpt, keta, kphi, kmass)")
-        Q2_extrap_hist["SBs"] = dataframe["SBs"].Filter(filterLSB).Histo1D(("Q_sqLSB_extrap","Q_sqLSB_extrap;  q^{2} [GeV^{2}];",20,5.5,10),"Q_sq_extrap")
+        if isfail:
+            Q2_extrap_hist["SBs"] = dataframe["SBs"].Filter(filterLSB).Histo1D(("Q_sqLSB_extrap","Q_sqLSB_extrap;  q^{2} [GeV^{2}];",20,5.5,10),"Q_sq_extrap", 'fakerate_data_2')
+        else:
+            Q2_extrap_hist["SBs"] = dataframe["SBs"].Filter(filterLSB).Histo1D(("Q_sqLSB_extrap","Q_sqLSB_extrap;  q^{2} [GeV^{2}];",20,5.5,10),"Q_sq_extrap")
         #DimuonShape = Q2_extrap_hist["SBs"].GetValue()
         DimuonShape = Q2_extrap_hist["SBs"]
     elif var_index == 1:
         dataframe["SBs"] = dataframe["SBs"].Filter(filterLSB).Define("m_miss_sq_extrap", "SB_extrap(Bpt_reco, 1, Jpsi_scale, mu1pt, mu1eta, mu1phi, mu1mass, mu2pt, mu2eta, mu2phi, mu2mass, kpt, keta, kphi, kmass)")
-        m_miss_extrap_hist["SBs"] = dataframe["SBs"].Filter(filterLSB).Histo1D(("m_miss_sqLSB_extrap","m_miss_sq_extrap;  q^{2} [GeV^{2}];",50,0,9),"m_miss_sq_extrap")
-        #DimuonShape = m_miss_extrap_hist["SBs"].GetValue()
+        if isfail:
+            m_miss_extrap_hist["SBs"] = dataframe["SBs"].Filter(filterLSB).Histo1D(("m_miss_sqLSB_extrap","m_miss_sq_extrap;  q^{2} [GeV^{2}];",50,0,9),"m_miss_sq_extrap", 'fakerate_data_2')
+        else:
+            m_miss_extrap_hist["SBs"] = dataframe["SBs"].Filter(filterLSB).Histo1D(("m_miss_sqLSB_extrap","m_miss_sq_extrap;  q^{2} [GeV^{2}];",50,0,9),"m_miss_sq_extrap")
         DimuonShape = m_miss_extrap_hist["SBs"]
     elif var_index == 2:
         dataframe["SBs"] = dataframe["SBs"].Filter(filterLSB).Define("pt_var_extrap", "SB_extrap(Bpt_reco, 2, Jpsi_scale, mu1pt, mu1eta, mu1phi, mu1mass, mu2pt, mu2eta, mu2phi, mu2mass, kpt, keta, kphi, kmass)")
-        pt_var_extrap_hist["SBs"] = dataframe["SBs"].Filter(filterLSB).Histo1D(("pt_varLSB_extrap","pt_var_extrap;  p_{T}^{var} [GeV];",50,0,50),"pt_var_extrap")
-        #DimuonShape = pt_var_extrap_hist["SBs"].GetValue()
+        if isfail:
+            pt_var_extrap_hist["SBs"] = dataframe["SBs"].Filter(filterLSB).Histo1D(("pt_varLSB_extrap","pt_var_extrap;  p_{T}^{var} [GeV];",50,0,50),"pt_var_extrap", 'fakerate_data_2')
+        else:
+            pt_var_extrap_hist["SBs"] = dataframe["SBs"].Filter(filterLSB).Histo1D(("pt_varLSB_extrap","pt_var_extrap;  p_{T}^{var} [GeV];",50,0,50),"pt_var_extrap")
         DimuonShape = pt_var_extrap_hist["SBs"]
     elif var_index == 3:
         dataframe["SBs"] = dataframe["SBs"].Filter(filterLSB).Define("pt_miss_vec_extrap", "SB_extrap(Bpt_reco, 3, Jpsi_scale, mu1pt, mu1eta, mu1phi, mu1mass, mu2pt, mu2eta, mu2phi, mu2mass, kpt, keta, kphi, kmass)")
-        pt_miss_vec_extrap_hist["SBs"] = dataframe["SBs"].Filter(filterLSB).Histo1D(("pt_miss_vecLSB_extrap","pt_miss_vec_extrap;  vector p_{T}^{miss} [GeV];",50,0,30),"pt_miss_vec_extrap")
-        #imuonShape = pt_miss_vec_extrap_hist["SBs"].GetValue()
-        DimuonShape = pt_miss_vec_extrap_hist["SBs"].GetValue()
+        if isfail:
+            pt_miss_vec_extrap_hist["SBs"] = dataframe["SBs"].Filter(filterLSB).Histo1D(("pt_miss_vecLSB_extrap","pt_miss_vec_extrap;  vector p_{T}^{miss} [GeV];",50,0,30),"pt_miss_vec_extrap", 'fakerate_data_2')
+        else:
+            pt_miss_vec_extrap_hist["SBs"] = dataframe["SBs"].Filter(filterLSB).Histo1D(("pt_miss_vecLSB_extrap","pt_miss_vec_extrap;  vector p_{T}^{miss} [GeV];",50,0,30),"pt_miss_vec_extrap")
+        DimuonShape = pt_miss_vec_extrap_hist["SBs"]
     elif var_index == 4:
         dataframe["SBs"] = dataframe["SBs"].Filter(filterLSB).Define("pt_miss_scal_extrap", "SB_extrap(Bpt_reco, 4, Jpsi_scale, mu1pt, mu1eta, mu1phi, mu1mass, mu2pt, mu2eta, mu2phi, mu2mass, kpt, keta, kphi, kmass)")
-        pt_miss_extrap_hist["SBs"] = dataframe["SBs"].Filter(filterLSB).Histo1D(("pt_miss_scalLSB_extrap","pt_miss_scal_extrap;  scalar p_{T}^{miss} [GeV];",60,-10,50),"pt_miss_scal_extrap")
-        DimuonShape = pt_miss_scal_extrap_hist["SBs"].GetValue()
+        if isfail:
+            pt_miss_extrap_hist["SBs"] = dataframe["SBs"].Filter(filterLSB).Histo1D(("pt_miss_scalLSB_extrap","pt_miss_scal_extrap;  scalar p_{T}^{miss} [GeV];",60,-10,50),"pt_miss_scal_extrap", 'fakerate_data_2')
+        else:
+            pt_miss_extrap_hist["SBs"] = dataframe["SBs"].Filter(filterLSB).Histo1D(("pt_miss_scalLSB_extrap","pt_miss_scal_extrap;  scalar p_{T}^{miss} [GeV];",60,-10,50),"pt_miss_scal_extrap")
+        DimuonShape = pt_miss_scal_extrap_hist["SBs"] 
     elif var_index == 5:
         # This is the variable to be used for the HM (channel 3, pass,  and channel 4, fail). Since it's a vertex variable, the extrapolation from SB to SR with the techinque is not needed. Indeed, this extrapolation rescales the mass part of the 4-momentum of the Jpsi 4-momentum. Since vertex variables are not touched, we can simply move the variable from the SB to the SR.
-        jpsivtx_log10_lxy_sig_estrap_hist["SBs"] = dataframe["SBs"].Filter(filterLSB).Histo1D(("jpsivtx_log10_lxy_sigLSB_extrap","jpsivtx_log10_lxy_sig_extrap; log_{10} vtx(#mu_{1}, #mu_{2}) L_{xy}/#sigma_{L_{xy}};",20,-1,1),"jpsivtx_log10_lxy_sig")
+        if isfail:
+            jpsivtx_log10_lxy_sig_estrap_hist["SBs"] = dataframe["SBs"].Filter(filterLSB).Histo1D(("jpsivtx_log10_lxy_sigLSB_extrap","jpsivtx_log10_lxy_sig_extrap; log_{10} vtx(#mu_{1}, #mu_{2}) L_{xy}/#sigma_{L_{xy}};",20,-1,1),"jpsivtx_log10_lxy_sig", 'fakerate_data_2')
+        else:
+            jpsivtx_log10_lxy_sig_estrap_hist["SBs"] = dataframe["SBs"].Filter(filterLSB).Histo1D(("jpsivtx_log10_lxy_sigLSB_extrap","jpsivtx_log10_lxy_sig_extrap; log_{10} vtx(#mu_{1}, #mu_{2}) L_{xy}/#sigma_{L_{xy}};",20,-1,1),"jpsivtx_log10_lxy_sig")
         DimuonShape = jpsivtx_log10_lxy_sig_estrap_hist["SBs"]
         
     if(sanitycheck):
@@ -274,7 +291,8 @@ def get_DiMuonBkg(selection, var_index):
     SBdataset   = ROOT.RooDataHist("SBdataset", "SBdataset", ROOT.RooArgList(massSB), HJpsimassSB)
     framemassSB = massSB.frame(ROOT.RooFit.Name(""), ROOT.RooFit.Title(""), ROOT.RooFit.Bins(200))
     SBdataset.plotOn(framemassSB,ROOT.RooFit.Binning(200, 2, 4),ROOT.RooFit.MarkerSize(1.5))
-    PDFSB.fitTo(SBdataset,ROOT.RooFit.Save())
+    PDFSB.fitTo(SBdataset,ROOT.RooFit.Save(),RooFit.PrintLevel(-1),RooFit.PrintEvalErrors(-1))
+
     PDFSB.plotOn(framemassSB)
     if(sanitycheck):
         JpsiMassSBCanvas = TCanvas("FitShapeJpsiMassSB", "FitShapeJpsiMassSB")
@@ -292,7 +310,7 @@ def get_DiMuonBkg(selection, var_index):
     SRdataset.plotOn(framemass,ROOT.RooFit.Name("data"),ROOT.RooFit.Binning(200, 2, 4))
     bkgSlope.setConstant(ROOT.kTRUE)
     bkgSlope.setVal(BkgShapetoFix)
-    CompletePDF.fitTo(SRdataset,ROOT.RooFit.Save())
+    CompletePDF.fitTo(SRdataset,ROOT.RooFit.Save(),RooFit.PrintLevel(-1),RooFit.PrintEvalErrors(-1))
     CompletePDF.plotOn(framemass)
     CompletePDF.plotOn(framemass,ROOT.RooFit.Components("Expo"),ROOT.RooFit.LineColor(ROOT.kGreen),ROOT.RooFit.FillColor(ROOT.kGreen),ROOT.RooFit.DrawOption("F"),ROOT.RooFit.MoveToBack())
     CompletePDF.plotOn(framemass,ROOT.RooFit.Components("CBall"),ROOT.RooFit.LineColor(ROOT.kGray),ROOT.RooFit.FillColor(ROOT.kGray),ROOT.RooFit.DrawOption("F"),ROOT.RooFit.MoveToBack())

--- a/plotting/showplots_v15.py
+++ b/plotting/showplots_v15.py
@@ -752,18 +752,18 @@ if __name__ == '__main__':
                     if k == 'Q_sq': #changed 15_03_2022
                         if compute_dimuon:
                             print("Doing the Dimuon",k)
-                            temp_hists[k]['%s_dimuon'%k] = get_DiMuonBkg(pass_id+" & Bmass<6.3 & Q_sq>5.5", 0)
-                            temp_hists_fake[k]['%s_dimuon'%k] = get_DiMuonBkg(fail_id+" & Bmass<6.3 & Q_sq>5.5", 0)
+                            temp_hists[k]['%s_dimuon'%k] = get_DiMuonBkg(pass_id+" & Bmass<6.3 & Q_sq>5.5", 0, 0)
+                            temp_hists_fake[k]['%s_dimuon'%k] = get_DiMuonBkg(fail_id+" & Bmass<6.3 & Q_sq>5.5", 0, 1)
                             if not flat_fakerate:
-                                temp_hists_fake_nn[k]['%s_dimuon'%k] = get_DiMuonBkg(fail_id+" & Bmass<6.3 & Q_sq>5.5", 0)
+                                temp_hists_fake_nn[k]['%s_dimuon'%k] = get_DiMuonBkg(fail_id+" & Bmass<6.3 & Q_sq>5.5", 0, 0)
                 if iteration:
                     if k == 'jpsivtx_log10_lxy_sig':  #changed from this line 15_03_2022 up to
                         if compute_dimuon:
                             print("Doing the Dimuon",k)
-                            temp_hists[k]['%s_dimuon'%k] = get_DiMuonBkg(pass_id+" & Bmass>6.3", 5)
-                            temp_hists_fake[k]['%s_dimuon'%k] = get_DiMuonBkg(fail_id+" & Bmass>6.3", 5)
+                            temp_hists[k]['%s_dimuon'%k] = get_DiMuonBkg(pass_id+" & Bmass>6.3", 5, 0)
+                            temp_hists_fake[k]['%s_dimuon'%k] = get_DiMuonBkg(fail_id+" & Bmass>6.3", 5, 1)
                             if not flat_fakerate:
-                                temp_hists_fake_nn[k]['%s_dimuon'%k] = get_DiMuonBkg(fail_id+" & Bmass>6.3", 5)  #changed up to this line 15_03_2022
+                                temp_hists_fake_nn[k]['%s_dimuon'%k] = get_DiMuonBkg(fail_id+" & Bmass>6.3", 5, 0)  #changed up to this line 15_03_2022
                         #else:
                         #take it from a file
                         


### PR DESCRIPTION
This pull request includes the fake categories for the DiMuon background, ch2 and ch4, using the latest files produced by Federica:

1. datalowmass_fakerate_only_iso.root (March 16)
2. data_fakerate_only_iso.root (Feb 7)

It also reduces the output fit details (Verbose -1). 

The fake weights used are stores as branch fakerate_data_2 in the corresponding trees. 

Files updated: DiMuon.py and showplots_v15.py 